### PR TITLE
feat(dev-env): add Docker development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ apps/*/src/generated
 # Variables d'environnement (garder les .env.example)
 .env
 apps/*/.env
+infrastructure/.env
 
 .angular

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install format-check format-fix lint-check lint-fix linter-check linter-fix test
+.PHONY: help install format-check format-fix lint-check lint-fix linter-check linter-fix test docker-up docker-up-detached docker-down docker-logs docker-reset docker-config
 
 help:
 	@printf '\n\033[1;36mLagonaDeck\033[0m - commandes disponibles\n'
@@ -18,6 +18,13 @@ help:
 	@printf '  \033[2m(alias: linter-check / linter-fix)\033[0m\n'
 	@printf '\n\033[1;33mTests\033[0m\n'
 	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make test' 'Exécute les tests de tous les projets'
+	@printf '\n\033[1;33mDocker (développement)\033[0m\n'
+	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make docker-up' 'Construit et démarre l’environnement de développement'
+	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make docker-up-detached' 'Construit et démarre l’environnement en arrière-plan'
+	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make docker-down' 'Arrête l’environnement en conservant les données'
+	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make docker-logs' 'Suit les logs de tous les services'
+	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make docker-reset' 'Supprime les conteneurs et volumes de développement'
+	@printf '  \033[1;32m%-20s\033[0m %s\n' 'make docker-config' 'Affiche la configuration Compose résolue'
 	@printf '\n\033[2mUtilisation : make <commande>\033[0m\n\n'
 
 install:
@@ -37,3 +44,22 @@ lint-fix linter-fix:
 
 test:
 	npm test
+
+COMPOSE_DEV = docker compose -f infrastructure/docker-compose.dev.yml
+
+docker-up:
+	$(COMPOSE_DEV) up --build
+
+docker-up-detached:
+	$(COMPOSE_DEV) up --build --detach
+
+docker-down:
+	$(COMPOSE_DEV) down
+
+docker-logs:
+	$(COMPOSE_DEV) logs -f --tail=200
+
+docker-reset:
+	$(COMPOSE_DEV) down --volumes --remove-orphans
+
+docker-config:

--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,4 @@ docker-reset:
 	$(COMPOSE_DEV) down --volumes --remove-orphans
 
 docker-config:
+	$(COMPOSE_DEV) config

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ docs/                  architecture, diagrammes, API, ADR
 
 ## Démarrage
 
+### Docker (recommandé)
+
+L'environnement de développement complet se lance avec Docker et Docker Compose ;
+Node.js, PostgreSQL, RabbitMQ et MinIO ne sont alors pas requis sur la machine
+hôte.
+
+```bash
+make docker-up
+```
+
+Pour le lancer en arrière-plan, utilisez `make docker-up-detached`. Les URL,
+variables, volumes, commandes d'arrêt, réinitialisation, hot reload et
+dépannage sont détaillés dans le [guide Docker de développement](docs/development/docker-development.md).
+
+### Sans Docker
+
 ```bash
 # Installer les dépendances
 npm install

--- a/docs/development/docker-development.md
+++ b/docs/development/docker-development.md
@@ -1,0 +1,144 @@
+# Environnement Docker de développement
+
+Ce guide décrit l'environnement de développement local de LagonaDeck. Il lance
+le monorepo Nx, PostgreSQL, RabbitMQ et MinIO avec Docker Compose. Les sources
+sont montées dans les conteneurs ; le frontend et les services NestJS se
+recompilent automatiquement après une modification.
+
+## Prérequis
+
+- Docker Engine 26+ ou Docker Desktop récent ;
+- Docker Compose v2 (`docker compose version`) ;
+- GNU Make pour les raccourcis `make` (les commandes Compose équivalentes sont
+  indiquées ci-dessous).
+
+Node.js, npm, PostgreSQL, RabbitMQ et MinIO ne sont pas nécessaires sur la
+machine hôte. L'environnement a été validé avec Docker Desktop et Docker
+Compose v5.
+
+## Premier démarrage
+
+Depuis la racine du dépôt :
+
+```bash
+# Affiche les commandes disponibles
+make help
+
+# Construit les images et affiche les logs au premier plan
+make docker-up
+
+# Variante en arrière-plan
+make docker-up-detached
+```
+
+La première exécution télécharge les images et installe les dépendances npm dans
+le volume Docker dédié : elle est donc plus lente. Les exécutions suivantes
+réutilisent les couches et les volumes existants.
+
+Sans Make, exécutez :
+
+```bash
+docker compose -f infrastructure/docker-compose.dev.yml up --build
+```
+
+## Services et accès local
+
+| Service     | URL ou port hôte                            | Usage                       |
+| ----------- | ------------------------------------------- | --------------------------- |
+| Frontend    | <http://localhost:4200>                     | Application Angular         |
+| API Gateway | <http://localhost:3000/api>                 | Point d'entrée HTTP         |
+| Identity    | <http://localhost:3001/api>                 | Service métier              |
+| Catalog     | <http://localhost:3002/api>                 | Service métier              |
+| Inventory   | <http://localhost:3003/api>                 | Service métier              |
+| Sales       | <http://localhost:3004/api>                 | Service métier              |
+| Analytics   | <http://localhost:3005/api>                 | Service métier              |
+| Media       | <http://localhost:3006/api>                 | Service métier              |
+| PostgreSQL  | `localhost:5432`                            | Base locale (configurable)  |
+| RabbitMQ    | `localhost:5672` / <http://localhost:15672> | AMQP / interface de gestion |
+| MinIO       | `localhost:9000` / <http://localhost:9001>  | API S3 / console            |
+
+Les applications communiquent entre elles et avec les dépendances via le réseau
+Compose et les noms de services (`postgres`, `rabbitmq`, `minio`), jamais via
+`localhost` dans les conteneurs. PostgreSQL initialise six bases isolées :
+`lagonadeck_identity`, `lagonadeck_catalog`, `lagonadeck_inventory`,
+`lagonadeck_sales`, `lagonadeck_analytics` et `lagonadeck_media`.
+
+## Variables de développement
+
+Copiez le fichier d'exemple uniquement si vous devez modifier les valeurs par
+défaut :
+
+```bash
+cp infrastructure/.env.example infrastructure/.env
+```
+
+`infrastructure/.env` est ignoré par Git. Les variables disponibles sont :
+
+| Variable              | Défaut  | Effet                                                                                |
+| --------------------- | ------- | ------------------------------------------------------------------------------------ |
+| `POSTGRES_PORT`       | `5432`  | Port PostgreSQL exposé sur l'hôte. Utilisez `15432` si le port 5432 est déjà occupé. |
+| `CHOKIDAR_USEPOLLING` | `false` | Active le polling pour Angular.                                                      |
+| `WATCHPACK_POLLING`   | `false` | Active le polling pour les watchers webpack/Nx.                                      |
+
+Sur Docker Desktop, WSL ou un partage réseau, les notifications du système de
+fichiers peuvent ne pas être remontées dans le bind mount. Passez les deux
+variables de polling à `true` dans `infrastructure/.env`, puis relancez la
+stack. Le polling augmente l'usage CPU.
+
+Les identifiants présents dans le Compose sont réservés au développement local.
+Ils ne doivent jamais être réutilisés en recette ou en production ; aucun secret
+réel ne doit être ajouté au dépôt.
+
+## Hot reload
+
+- Le frontend Angular est servi avec `nx serve frontend` : les changements
+  TypeScript, templates, styles et assets provoquent un rebuild et une mise à
+  jour du navigateur.
+- Chaque application NestJS lance son daemon Nx dans un répertoire temporaire
+  propre au conteneur. Un changement TypeScript déclenche un rebuild puis un
+  redémarrage du processus Node.
+- Les clients Prisma sont générés séquentiellement par le conteneur ponctuel
+  `prisma-generate` au démarrage. Son état `Exited (0)` est normal, tout comme
+  celui de `minio-init`, qui crée le bucket une seule fois.
+
+Les fichiers de configuration (`package.json`, `package-lock.json`, Dockerfile,
+Compose, `.env`) ne sont pas rechargés à chaud. Après une modification, relancez
+la stack avec `make docker-down` puis `make docker-up`.
+
+## Exploitation locale
+
+```bash
+# État et healthchecks des conteneurs
+docker compose -f infrastructure/docker-compose.dev.yml ps
+
+# Suivre les logs de tous les services
+make docker-logs
+
+# Arrêter en préservant données et dépendances npm
+make docker-down
+
+# Supprimer conteneurs ET volumes de développement (irréversible)
+make docker-reset
+```
+
+Les volumes nommés sont `postgres_data`, `rabbitmq_data`, `minio_data` et
+`node_modules`. `make docker-reset` les supprime ; la prochaine exécution
+recrée les bases, le bucket MinIO et les dépendances.
+
+## Dépannage
+
+| Symptôme                                           | Action                                                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Le port 5432 est déjà pris                         | Créez `infrastructure/.env` avec `POSTGRES_PORT=15432`, puis relancez.                                                         |
+| Un port HTTP est déjà pris                         | Arrêtez le processus concerné ou adaptez le mapping dans le Compose.                                                           |
+| Aucun changement n'est détecté                     | Activez les deux variables de polling, puis relancez.                                                                          |
+| Prisma ou les dépendances npm semblent incohérents | Lancez `make docker-reset`, puis `make docker-up`.                                                                             |
+| Un service ne devient pas `healthy`                | Consultez `make docker-logs` ou les logs ciblés avec `docker compose -f infrastructure/docker-compose.dev.yml logs <service>`. |
+
+## Vérifications effectuées
+
+Sur l'environnement Docker de développement supporté, les vérifications
+suivantes ont été réalisées : démarrage complet, healthchecks de tous les
+services persistants, génération Prisma, initialisation MinIO, arrêt et
+redémarrage, rebuild Angular avec mise à jour client, et modification TypeScript
+d'un service NestJS avec recompilation puis redémarrage automatique.

--- a/infrastructure/.env.example
+++ b/infrastructure/.env.example
@@ -1,0 +1,10 @@
+# Copiez ce fichier vers infrastructure/.env pour surcharger les valeurs de
+# développement. Le fichier .env est ignoré par Git.
+
+# Port PostgreSQL exposé sur la machine hôte. Utilisez 15432 si 5432 est pris.
+POSTGRES_PORT=5432
+
+# Activez le polling seulement si Docker Desktop, WSL ou un partage réseau ne
+# transmet pas les événements de fichiers aux bind mounts. Cela consomme plus de CPU.
+CHOKIDAR_USEPOLLING=false
+WATCHPACK_POLLING=false

--- a/infrastructure/docker-compose.dev.yml
+++ b/infrastructure/docker-compose.dev.yml
@@ -83,7 +83,8 @@ services:
 
   prisma-generate:
     <<: *application
-    build: { context: .., dockerfile: infrastructure/docker/identity/Dockerfile }
+    build:
+      { context: .., dockerfile: infrastructure/docker/identity/Dockerfile }
     environment:
       <<: *application-environment
       DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_identity?schema=public

--- a/infrastructure/docker-compose.dev.yml
+++ b/infrastructure/docker-compose.dev.yml
@@ -1,0 +1,266 @@
+name: lagonadeck-dev
+
+x-application: &application
+  working_dir: /workspace
+  volumes:
+    - ..:/workspace
+    - node_modules:/workspace/node_modules
+  environment: &application-environment
+    NODE_ENV: development
+    NX_DAEMON: 'true'
+    # L'état Nx ne doit pas être partagé entre les conteneurs : chaque watcher
+    # dispose de son daemon et de son cache éphémères.
+    NX_WORKSPACE_DATA_DIRECTORY: /tmp/nx/workspace-data
+    NX_CACHE_DIRECTORY: /tmp/nx/cache
+    CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-false}
+    WATCHPACK_POLLING: ${WATCHPACK_POLLING:-false}
+  init: true
+
+x-database-service: &database-service
+  <<: *application
+  depends_on:
+    postgres:
+      condition: service_healthy
+    prisma-generate:
+      condition: service_completed_successfully
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: lagonadeck
+      POSTGRES_PASSWORD: lagonadeck
+      POSTGRES_DB: postgres
+    ports: ['${POSTGRES_PORT:-5432}:5432']
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./postgres/init-databases.sql:/docker-entrypoint-initdb.d/01-databases.sql:ro
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U lagonadeck -d postgres']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:4-management-alpine
+    environment:
+      RABBITMQ_DEFAULT_USER: lagonadeck
+      RABBITMQ_DEFAULT_PASS: lagonadeck
+    ports: ['5672:5672', '15672:15672']
+    volumes: [rabbitmq_data:/var/lib/rabbitmq]
+    healthcheck:
+      test: ['CMD-SHELL', 'rabbitmq-diagnostics -q ping']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: lagonadeck
+      MINIO_ROOT_PASSWORD: lagonadeck-dev-password
+    ports: ['9000:9000', '9001:9001']
+    volumes: [minio_data:/data]
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >-
+      /bin/sh -c "mc alias set local http://minio:9000 lagonadeck lagonadeck-dev-password
+      && mc mb --ignore-existing local/lagonadeck-media"
+    restart: 'no'
+
+  prisma-generate:
+    <<: *application
+    build: { context: .., dockerfile: infrastructure/docker/identity/Dockerfile }
+    environment:
+      <<: *application-environment
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_identity?schema=public
+    command: >-
+      sh -c 'npm run db:generate -w @lagonadeck/identity-service
+      && npm run db:generate -w @lagonadeck/catalog-service
+      && npm run db:generate -w @lagonadeck/inventory-service
+      && npm run db:generate -w @lagonadeck/sales-service
+      && npm run db:generate -w @lagonadeck/analytics-service
+      && npm run db:generate -w @lagonadeck/media-service'
+    restart: 'no'
+
+  frontend:
+    <<: *application
+    build:
+      { context: .., dockerfile: infrastructure/docker/frontend/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve frontend --host=0.0.0.0'
+    ports: ['4200:4200']
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:4200'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  api-gateway:
+    <<: *application
+    build:
+      { context: .., dockerfile: infrastructure/docker/api-gateway/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve api-gateway'
+    environment:
+      <<: *application-environment
+      PORT: '3000'
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+    ports: ['3000:3000']
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    healthcheck: &api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3000/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  identity-service:
+    <<: *database-service
+    build:
+      { context: .., dockerfile: infrastructure/docker/identity/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve identity-service'
+    environment:
+      <<: *application-environment
+      PORT: '3001'
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_identity?schema=public
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+    ports: ['3001:3001']
+    healthcheck:
+      <<: *api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3001/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+
+  catalog-service:
+    <<: *database-service
+    build: { context: .., dockerfile: infrastructure/docker/catalog/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve catalog-service'
+    environment:
+      <<: *application-environment
+      PORT: '3002'
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_catalog?schema=public
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+    ports: ['3002:3002']
+    healthcheck:
+      <<: *api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3002/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+
+  inventory-service:
+    <<: *database-service
+    build:
+      { context: .., dockerfile: infrastructure/docker/inventory/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve inventory-service'
+    environment:
+      <<: *application-environment
+      PORT: '3003'
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_inventory?schema=public
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+    ports: ['3003:3003']
+    healthcheck:
+      <<: *api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3003/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+
+  sales-service:
+    <<: *database-service
+    build: { context: .., dockerfile: infrastructure/docker/sales/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve sales-service'
+    environment:
+      <<: *application-environment
+      PORT: '3004'
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_sales?schema=public
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+    ports: ['3004:3004']
+    healthcheck:
+      <<: *api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3004/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+
+  analytics-service:
+    <<: *database-service
+    build:
+      { context: .., dockerfile: infrastructure/docker/analytics/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve analytics-service'
+    environment:
+      <<: *application-environment
+      PORT: '3005'
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_analytics?schema=public
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+    ports: ['3005:3005']
+    healthcheck:
+      <<: *api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3005/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+
+  media-service:
+    <<: *database-service
+    build: { context: .., dockerfile: infrastructure/docker/media/Dockerfile }
+    command: sh -c 'npx nx daemon --start && exec npx nx serve media-service'
+    environment:
+      <<: *application-environment
+      PORT: '3006'
+      DATABASE_URL: postgresql://lagonadeck:lagonadeck@postgres:5432/lagonadeck_media?schema=public
+      RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
+      MEDIA_S3_ENDPOINT: http://minio:9000
+      MEDIA_S3_REGION: us-east-1
+      MEDIA_S3_BUCKET: lagonadeck-media
+      MEDIA_S3_ACCESS_KEY_ID: lagonadeck
+      MEDIA_S3_SECRET_ACCESS_KEY: lagonadeck-dev-password
+      MEDIA_S3_FORCE_PATH_STYLE: 'true'
+    ports: ['3006:3006']
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      <<: *api-health
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://localhost:3006/api'').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+
+volumes:
+  node_modules:
+  postgres_data:
+  rabbitmq_data:
+  minio_data:

--- a/infrastructure/docker-compose.dev.yml
+++ b/infrastructure/docker-compose.dev.yml
@@ -1,10 +1,16 @@
 name: lagonadeck-dev
 
-x-application: &application
+x-application-base: &application-base
   working_dir: /workspace
   volumes:
     - ..:/workspace
     - node_modules:/workspace/node_modules
+
+x-application: &application
+  <<: *application-base
+  depends_on: &application-depends
+    install-dependencies:
+      condition: service_completed_successfully
   environment: &application-environment
     NODE_ENV: development
     NX_DAEMON: 'true'
@@ -19,6 +25,7 @@ x-application: &application
 x-database-service: &database-service
   <<: *application
   depends_on:
+    <<: *application-depends
     postgres:
       condition: service_healthy
     prisma-generate:
@@ -81,6 +88,18 @@ services:
       && mc mb --ignore-existing local/lagonadeck-media"
     restart: 'no'
 
+  install-dependencies:
+    <<: *application-base
+    build:
+      { context: .., dockerfile: infrastructure/docker/identity/Dockerfile }
+    command: >-
+      sh -c 'lock_hash="$$(sha256sum package-lock.json | cut -d " " -f1)";
+      marker=node_modules/.lagonadeck-package-lock;
+      if [ ! -f "$$marker" ] || [ "$$(cat "$$marker")" != "$$lock_hash" ]; then
+      npm ci --ignore-scripts --workspaces=false && printf "%s\\n" "$$lock_hash" > "$$marker";
+      fi'
+    restart: 'no'
+
   prisma-generate:
     <<: *application
     build:
@@ -125,6 +144,7 @@ services:
       RABBITMQ_URL: amqp://lagonadeck:lagonadeck@rabbitmq:5672
     ports: ['3000:3000']
     depends_on:
+      <<: *application-depends
       rabbitmq:
         condition: service_healthy
     healthcheck: &api-health
@@ -248,6 +268,7 @@ services:
       MEDIA_S3_FORCE_PATH_STYLE: 'true'
     ports: ['3006:3006']
     depends_on:
+      <<: *application-depends
       postgres:
         condition: service_healthy
       minio-init:

--- a/infrastructure/docker/analytics/Dockerfile
+++ b/infrastructure/docker/analytics/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/api-gateway/Dockerfile
+++ b/infrastructure/docker/api-gateway/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/catalog/Dockerfile
+++ b/infrastructure/docker/catalog/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/frontend/Dockerfile
+++ b/infrastructure/docker/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/identity/Dockerfile
+++ b/infrastructure/docker/identity/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/inventory/Dockerfile
+++ b/infrastructure/docker/inventory/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/media/Dockerfile
+++ b/infrastructure/docker/media/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/docker/sales/Dockerfile
+++ b/infrastructure/docker/sales/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+COPY package.json package-lock.json ./
+RUN apt-get update && apt-get install --yes --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+RUN npm install --global npm@12.0.2 && npm ci --ignore-scripts --workspaces=false && chown -R node:node /workspace/node_modules
+
+USER node
+

--- a/infrastructure/postgres/init-databases.sql
+++ b/infrastructure/postgres/init-databases.sql
@@ -1,0 +1,6 @@
+CREATE DATABASE lagonadeck_identity;
+CREATE DATABASE lagonadeck_catalog;
+CREATE DATABASE lagonadeck_inventory;
+CREATE DATABASE lagonadeck_sales;
+CREATE DATABASE lagonadeck_analytics;
+CREATE DATABASE lagonadeck_media;


### PR DESCRIPTION
## Summary
- add Docker Compose development stack with PostgreSQL, RabbitMQ, MinIO and all Nx applications
- add Docker development commands to the Makefile
- document setup, hot reload, volumes, troubleshooting and reset workflow

Closes #26

## Validation
- `make docker-config`
- Docker Compose startup with all persistent services healthy
- Angular watch rebuild and client update
- NestJS TypeScript rebuild and automatic restart
- clean stop and detached restart
- Prettier and pre-push lint checks